### PR TITLE
Support forked invocation, use opam-depext and install depexts on REV_DEPS

### DIFF
--- a/.travis-mirage.sh
+++ b/.travis-mirage.sh
@@ -2,8 +2,11 @@
 
 set -ex
 
+# If a fork of these scripts are specified, use that GitHub user instead
+fork_user=${FORK_USER:-ocaml}
+
 ## fetch+execute the OCaml/opam setup script
-wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-ocaml.sh
+wget https://raw.githubusercontent.com/${fork_user}/ocaml-travisci-skeleton/master/.travis-ocaml.sh
 sh .travis-ocaml.sh
 
 ## install mirage

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -6,7 +6,7 @@ set -uex
 OCAML_VERSION=${OCAML_VERSION:-latest}
 
 case "$OCAML_VERSION" in
-    3.12) ppa=avsm/ocaml312+opam12 ;;
+    3.12) echo Pre 4.00 compilers are unsupported; exit 1 ;;
     4.00) ppa=avsm/ocaml40+opam12  ;;
     4.01) ppa=avsm/ocaml41+opam12  ;;
     4.02) ppa=avsm/ocaml42+opam12  ;;
@@ -27,6 +27,7 @@ export OPAMYES=1
 
 opam init -a git://github.com/ocaml/opam-repository
 eval $(opam config env)
+opam install depext
 
 opam --version
 opam --git-version

--- a/.travis-opam.sh
+++ b/.travis-opam.sh
@@ -52,9 +52,8 @@ opam pin add ${pkg} . -n
 eval $(opam config env)
 
 # Install the external dependencies
-if [ "$depext" != "" ]; then
-  opam depext ${pkg}
-fi
+echo "opam depext ${pkg}"
+opam depext ${pkg}
 
 # Install the OCaml dependencies
 echo "opam install ${pkg} --deps-only"

--- a/.travis-opam.sh
+++ b/.travis-opam.sh
@@ -15,6 +15,9 @@ tests_run=${TESTS:-true}
 # Run the reverse dependency rebuild step
 revdep_run=${REVDEPS:-false}
 
+# If a fork of these scripts are specified, use that GitHub user instead
+fork_user=${FORK_USER:-ocaml}
+
 # other variables
 EXTRA_DEPS=${EXTRA_DEPS:-""}
 PRE_INSTALL_HOOK=${PRE_INSTALL_HOOK:-""}
@@ -40,7 +43,7 @@ install() {
   fi
 }
 
-wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-ocaml.sh
+wget https://raw.githubusercontent.com/${fork_user}/ocaml-travisci-skeleton/master/.travis-ocaml.sh
 sh .travis-ocaml.sh
 export OPAMYES=1
 eval $(opam config env)

--- a/.travis-opam.sh
+++ b/.travis-opam.sh
@@ -49,17 +49,8 @@ opam pin add ${pkg} . -n
 eval $(opam config env)
 
 # Install the external dependencies
-depext=`opam list --required-by ${pkg} --rec -e ubuntu -s | tr '\n' ' ' | sed 's/ *$//'`
 if [ "$depext" != "" ]; then
-  echo Ubuntu depexts: "${depext}"
-  sudo apt-get install -qq ${depext}
-fi
-
-# Install the external source dependencies
-srcext=`opam list --required-by ${pkg} --rec -e source,linux -s | tr '\n' ' ' | sed 's/ *$//'`
-if [ "$srcext" != "" ]; then
-  echo Ubuntu srcext: "${srcext}"
-  curl -sL ${srcext} | bash
+  opam depext ${pkg}
 fi
 
 # Install the OCaml dependencies
@@ -104,6 +95,8 @@ fi
 if [ "${revdep_run}" != "false" ]; then
     packages=$(opam list --depends-on ${pkg} --short)
     for dependency in $packages; do
+        echo "opam depext ${dependency}"
+        opam depext ${dependency}
         echo "opam install ${dependency}"
         opam install ${dependency}
         echo "opam remove ${dependency}"


### PR DESCRIPTION
Also deprecates OCaml 3.12.1 for these particular scripts, unless @dbuenzli can add 3.12.1 support to cmdliner.