### PR TITLE
Silently using a modern compiler is failure for testing

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -6,11 +6,12 @@ set -uex
 OCAML_VERSION=${OCAML_VERSION:-latest}
 
 case "$OCAML_VERSION" in
-    3.12) echo Pre 4.00 compilers are unsupported; exit 1 ;;
+    3.12) ppa=avsm/ocaml312+opam12 ;;
     4.00) ppa=avsm/ocaml40+opam12  ;;
     4.01) ppa=avsm/ocaml41+opam12  ;;
     4.02) ppa=avsm/ocaml42+opam12  ;;
-    *)    ppa=avsm/ocaml42+opam12  ;;
+    latest) ppa=avsm/ppa-opam-experimental;;
+    *)    echo Unknown compiler version; exit 1;;
 esac
 
 sudo add-apt-repository \

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -1,5 +1,17 @@
 ## basic OCaml and opam installation
 
+full_apt_version () {
+  package=$1
+  version=$2
+  case "${version}" in
+      latest) echo -n "${package}" ;;
+      *) echo -n "${package}="
+         apt-cache show $package \
+             | sed -n "s/^Version: \(${version}\)/\1/p" \
+             | head -1
+  esac
+}
+
 set -uex
 
 # the ocaml version to test
@@ -19,8 +31,16 @@ sudo add-apt-repository \
 sudo add-apt-repository --yes ppa:${ppa}
 sudo apt-get update -qq
 sudo apt-get install -y \
-     ocaml ocaml-base ocaml-native-compilers ocaml-compiler-libs ocaml-interp \
-     ocaml-base-nox ocaml-nox camlp4 camlp4-extra opam
+     $(full_apt_version ocaml $OCAML_VERSION) \
+     $(full_apt_version ocaml-base $OCAML_VERSION) \
+     $(full_apt_version ocaml-native-compilers $OCAML_VERSION) \
+     $(full_apt_version ocaml-compiler-libs $OCAML_VERSION) \
+     $(full_apt_version ocaml-interp $OCAML_VERSION) \
+     $(full_apt_version ocaml-base-nox $OCAML_VERSION) \
+     $(full_apt_version ocaml-nox $OCAML_VERSION) \
+     $(full_apt_version camlp4 $OCAML_VERSION) \
+     $(full_apt_version camlp4-extra $OCAML_VERSION) \
+     opam
 
 ocaml -version
 


### PR DESCRIPTION
These two issues bit me during release of ipaddr 2.6.0:

1. There should not be a default compiler case.
2. Exactly what I ask for should be installed.