### PR TITLE
Add an EXTRA_REMOTE for opam repos with dev packages

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -16,6 +16,8 @@ set -uex
 
 # the ocaml version to test
 OCAML_VERSION=${OCAML_VERSION:-latest}
+# any extra repote of dev packages?
+EXTRA_REMOTE=${EXTRA_REMOTE:-""}
 
 case "$OCAML_VERSION" in
     3.12) ppa=avsm/ocaml312+opam12 ;;
@@ -48,6 +50,11 @@ export OPAMYES=1
 
 opam init -a git://github.com/ocaml/opam-repository
 eval $(opam config env)
+
+if [ "$EXTRA_REMOTE" != "" ]; then
+  opam remote add extra $EXTRA_REMOTE
+fi
+
 opam install depext
 
 opam --version


### PR DESCRIPTION
For example if I add a development library which doesn't exist in upstream to my opam-repo-dev  and then add a consumer, I can add my opem-repo-dev to EXTRA_REMOTE to make travis work on the consumer before releasing both to upstream opam-repository later.

What do you think?
