### PR TITLE
Run tests before optional dependencies in case depopts are dirty after uninstall

### DIFF
--- a/.travis-opam.sh
+++ b/.travis-opam.sh
@@ -69,6 +69,17 @@ else
     echo "INSTALL=false, skipping the basic installation run."
 fi
 
+# Compile and run the tests as well
+if [ "${tests_run}" == "true" ]; then
+    echo "opam install ${pkg} --deps-only -t"
+    opam install ${pkg} --deps-only -t
+    install -v -t
+    echo "opam remove ${pkg} -v"
+    opam remove ${pkg} -v
+else
+    echo "TESTS=false, skipping the test run."
+fi
+
 # Compile with optional dependencies
 if [ "${depopts_run}" != "false" ]; then
     # pick from $DEPOPTS if set or query OPAM
@@ -84,17 +95,6 @@ if [ "${depopts_run}" != "false" ]; then
     opam remove ${depopts}
 else
     echo "DEPOPTS=false, skipping the optional dependency run."
-fi
-
-# Compile and run the tests as well
-if [ "${tests_run}" == "true" ]; then
-    echo "opam install ${pkg} --deps-only -t"
-    opam install ${pkg} --deps-only -t
-    install -v -t
-    echo "opam remove ${pkg} -v"
-    opam remove ${pkg} -v
-else
-    echo "TESTS=false, skipping the test run."
 fi
 
 if [ "${revdep_run}" != "false" ]; then


### PR DESCRIPTION
Inspired by <https://travis-ci.org/mirage/ocaml-cohttp/jobs/58307674#L1819> and the subsequent failure on <https://travis-ci.org/mirage/ocaml-cohttp/jobs/58307674#L2216>. I don't know if this is actually the issue as I can't seem to reproduce the Travis failure.