### PR TITLE
If TESTS=true, run tests during DEPOPTS run, too.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ env:
   - [...] DEPOPTS="*" [...]
 ```
 
-An empty value or the value "false" will disable the optional dependency run.
+An empty value or the value "false" will disable the optional dependency
+run. If `TESTS` is `true` (default, see below), the package's tests will
+be run during the optional dependency run as well.
 
 ### Extra Dependencies
 

--- a/travis_opam.ml
+++ b/travis_opam.ml
@@ -131,15 +131,17 @@ end else echo "TESTS=false, skipping the test run."
 ;
 
 (* Compile with optional dependencies *)
-begin match depopts_run with
+begin
+  let args = if tests_run then ["-v"; "-t"] else ["-v"] in
+  match depopts_run with
   | [] | ["false"] ->
     echo "DEPOPTS=false, skipping the optional dependency run."
   | ["*"] -> (* query OPAM *)
     let depopts =
       ?|> "opam show %s | grep -oP 'depopts: \\K(.*)' | sed 's/ | / /g'" pkg
     in
-    install_with_depopts ["-v"] depopts
-  | depopts -> install_with_depopts ["-v"] (depopts *~ " ")
+    install_with_depopts args depopts
+  | depopts -> install_with_depopts args (depopts *~ " ")
 end;
 
 let revdeps = match revdep_run with


### PR DESCRIPTION
Fixes #30.

This hasn't been tested so it would be best to get @johnelse approval (or at least the scenario where he wanted this feature).