### PR TITLE
More abstraction; Add `DEV` repo

### DIFF
--- a/.travis-mirage.sh
+++ b/.travis-mirage.sh
@@ -42,12 +42,13 @@ if [ "$DEPLOY" = "1" \
 
     DEPLOYD=${TRAVIS_REPO_SLUG#*/}-deployment
     XENIMG=mir-${XENIMG:-$TRAVIS_REPO_SLUG#mirage/mirage-}.xen
+    MIRDIR=${MIRDIR:-src}
     case "$MIRAGE_BACKEND" in
         xen)
             cd $DEPLOYD
             rm -rf xen/$TRAVIS_COMMIT
             mkdir -p xen/$TRAVIS_COMMIT
-            cp ../src/$XENIMG ../src/config.ml xen/$TRAVIS_COMMIT
+            cp ../$MIRDIR/$XENIMG ../$MIRDIR/config.ml xen/$TRAVIS_COMMIT
             bzip2 -9 xen/$TRAVIS_COMMIT/$XENIMG
             echo $TRAVIS_COMMIT > xen/latest
             git add xen/$TRAVIS_COMMIT xen/latest

--- a/.travis-mirage.sh
+++ b/.travis-mirage.sh
@@ -30,18 +30,18 @@ if [ "$DEPLOY" = "1" \
     travis-senv decrypt > $SSH_DEPLOY_KEY
     chmod 600 $SSH_DEPLOY_KEY
 
-    echo "Host mir-deploy github.com" >> ~/.ssh/config
-    echo "   Hostname github.com" >> ~/.ssh/config
-    echo "   StrictHostKeyChecking no" >> ~/.ssh/config
-    echo "   CheckHostIP no" >> ~/.ssh/config
+    echo "Host mir-deploy github.com"      >> ~/.ssh/config
+    echo "   Hostname github.com"          >> ~/.ssh/config
+    echo "   StrictHostKeyChecking no"     >> ~/.ssh/config
+    echo "   CheckHostIP no"               >> ~/.ssh/config
     echo "   UserKnownHostsFile=/dev/null" >> ~/.ssh/config
 
     git config --global user.email "travis@openmirage.org"
     git config --global user.name "Travis the Build Bot"
     git clone git@mir-deploy:${TRAVIS_REPO_SLUG}-deployment
 
-    DEPLOYD=${TRAVIS_REPO_SLUG#mirage/}-deployment
-    XENIMG=mir-${TRAVIS_REPO_SLUG#mirage/mirage-}.xen
+    DEPLOYD=${TRAVIS_REPO_SLUG#*/}-deployment
+    XENIMG=mir-${XENIMG:-$TRAVIS_REPO_SLUG#mirage/mirage-}.xen
     case "$MIRAGE_BACKEND" in
         xen)
             cd $DEPLOYD

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -68,7 +68,7 @@ export OPAMYES=1
 opam init -a ${BASE_REMOTE}
 
 if [ "$DEV_REMOTE" != "" ] ; then
-    opam remote add $DEV_REMOTE
+    opam remote add dev $DEV_REMOTE
     opam update -u
 fi
 

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -67,7 +67,7 @@ export OPAMYES=1
 
 opam init -a ${BASE_REMOTE}
 
-f [ "$DEV_REMOTE" != "" ] ; then
+if [ "$DEV_REMOTE" != "" ] ; then
     opam remote add $DEV_REMOTE
     opam update -u
 fi

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -20,6 +20,9 @@ OCAML_VERSION=${OCAML_VERSION:-latest}
 # the base opam repository to use for bootstrapping and catch-all namespace
 BASE_REMOTE=${BASE_REMOTE:-git://github.com/ocaml/opam-repository}
 
+# add a development remote as well
+DEV_REMOTE=${DEV_REMOTE}
+
 # whether we need a new gcc and binutils
 UPDATE_GCC_BINUTILS=${UPDATE_GCC_BINUTILS:-"0"}
 
@@ -63,6 +66,12 @@ ocaml -version
 export OPAMYES=1
 
 opam init -a ${BASE_REMOTE}
+
+f [ "$DEV_REMOTE" != "" ] ; then
+    opam remote add $DEV_REMOTE
+    opam update -u
+fi
+
 eval $(opam config env)
 opam install depext
 


### PR DESCRIPTION
A bit more abstraction so I can use this to build my site; I think I left defaults correct so that existing usage still works.

Also add a new environment variable, `DEV_REMOTE` so that an additional OPAM repo can be specified, e.g., `mirage-dev`