### PR TITLE
RFC: Add support for updating docs on Github pages

### DIFF
--- a/.travis-docgen.sh
+++ b/.travis-docgen.sh
@@ -30,4 +30,4 @@ git -C $DOCDIR config user.email "travis@travis-ci.org"
 git -C $DOCDIR config user.name "Travis"
 git -C $DOCDIR add .
 git -C $DOCDIR commit --allow-empty -m "Travis build $TRAVIS_BUILD_NUMBER pushed docs to gh-pages"
-git -C $DOCDIR push origin gh-pages > /dev/null
+git -C $DOCDIR push origin gh-pages &2>1 > /dev/null

--- a/.travis-docgen.sh
+++ b/.travis-docgen.sh
@@ -18,6 +18,9 @@ DOCDIR=.gh-pages
 if [ -n "$KEEP" ]; then trap "rm -rf $DOCDIR" EXIT; fi
 rm -rf $DOCDIR
 
+# Error out if $GH_TOKEN is empty or unset
+: ${GH_TOKEN:?"GH_TOKEN need to be uploaded via travis-encrypt"}
+
 git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/simonjbeaumont/ocaml-pci $DOCDIR > /dev/null
 
 cp _build/pci.docdir/* $DOCDIR

--- a/.travis-docgen.sh
+++ b/.travis-docgen.sh
@@ -27,5 +27,6 @@ cp _build/pci.docdir/* $DOCDIR
 
 git -C $DOCDIR config user.email "travis@travis-ci.org"
 git -C $DOCDIR config user.name "Travis"
-git -C $DOCDIR commit --allow-empty -am "Travis build $TRAVIS_BUILD_NUMBER pushed docs to gh-pages"
+git -C $DOCDIR add .
+git -C $DOCDIR commit --allow-empty -m "Travis build $TRAVIS_BUILD_NUMBER pushed docs to gh-pages"
 git -C $DOCDIR push origin gh-pages > /dev/null

--- a/.travis-docgen.sh
+++ b/.travis-docgen.sh
@@ -21,7 +21,8 @@ rm -rf $DOCDIR
 # Error out if $GH_TOKEN is empty or unset
 : ${GH_TOKEN:?"GH_TOKEN need to be uploaded via travis-encrypt"}
 
-git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG} $DOCDIR > /dev/null
+git clone --quiet https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG} $DOCDIR
+git -C $DOCDIR checkout gh-pages || git -C $DOCDIR checkout --orphan gh-pages
 
 cp _build/*.docdir/* $DOCDIR
 

--- a/.travis-docgen.sh
+++ b/.travis-docgen.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+# Make sure we're not echoing any sensitive data
+set +x
+
+eval `opam config env`
+./configure --enable-docs
+make doc
+
+if [ -z "$TRAVIS" -o "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  echo "This is not a push Travis-ci build, doing nothing..."
+  exit 0
+else
+  echo "Updating docs on Github pages..."
+fi
+
+DOCDIR=.gh-pages
+if [ -n "$KEEP" ]; then trap "rm -rf $DOCDIR" EXIT; fi
+rm -rf $DOCDIR
+
+git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/simonjbeaumont/ocaml-pci $DOCDIR > /dev/null
+
+cp _build/pci.docdir/* $DOCDIR
+
+git -C $DOCDIR config user.email "travis@travis-ci.org"
+git -C $DOCDIR config user.name "Travis"
+git -C $DOCDIR commit --allow-empty -am "Travis build $TRAVIS_BUILD_NUMBER pushed docs to gh-pages"
+git -C $DOCDIR push origin gh-pages > /dev/null

--- a/.travis-docgen.sh
+++ b/.travis-docgen.sh
@@ -21,9 +21,9 @@ rm -rf $DOCDIR
 # Error out if $GH_TOKEN is empty or unset
 : ${GH_TOKEN:?"GH_TOKEN need to be uploaded via travis-encrypt"}
 
-git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/simonjbeaumont/ocaml-pci $DOCDIR > /dev/null
+git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG} $DOCDIR > /dev/null
 
-cp _build/pci.docdir/* $DOCDIR
+cp _build/*.docdir/* $DOCDIR
 
 git -C $DOCDIR config user.email "travis@travis-ci.org"
 git -C $DOCDIR config user.name "Travis"

--- a/.travis-docgen.sh
+++ b/.travis-docgen.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# From https://github.com/simonjbeaumont/ocaml-travis-gh-pages
+
 set -e
 # Make sure we're not echoing any sensitive data
 set +x

--- a/README.md
+++ b/README.md
@@ -245,3 +245,24 @@ os:
   - linux
   - osx
 ```
+
+## Pushing OCamldoc docs to Github page, `.travis-docgen.sh`
+
+This relies on the existence of a `configure` script and `Makefile` such that
+the docs are built as follows:
+
+```shell
+./configure --enable-docs
+make doc
+```
+
+It also relies on you uploading an OAuth token to your Travis job. To do this,
+create a token on your Github account settings page and upload it as follows:
+
+```shell
+gem install travis
+travis encrypt GH_TOKEN=<token> --add
+```
+
+It will then push the contents of the resulting `<lib>.docdir` to the Github
+pages branch of your repo.


### PR DESCRIPTION
I realise that this would probably need a bit of work to conform to the style of "script" in this repo. I've highlighted those in the pull request in the changes to the README but they'd be at least:

- [ ] Use Yorick rather than sh
- [ ] Support things in different places (i.e. you didn't use `oasis`)
- [ ] Use `travis-senv` in place of requiring `travis encrypt`ed `$GH_TOKEN`

Just wanted to see if this could in principle go in before I do any of that.

I've got it in use in a couple of repos (there are "badges" on the README linking to the self-hosted docs):
* https://github.com/xapi-project/backtrace
* https://github.com/simonjbeaumont/ocaml-pci