### PR TITLE
cache: remove extra pins before adding them back

### DIFF
--- a/travis_opam.ml
+++ b/travis_opam.ml
@@ -105,7 +105,15 @@ unset "TESTS";
 export "OPAMYES" "1";
 ?| "eval $(opam config env)";
 
-List.iter add_remote extra_remotes;
+begin (* remotes *)
+  let remotes =
+    ?|> "opam remote list --short | grep -v default | tr \"\\n\" \" \""
+  in
+  if remotes <> "" then begin
+    ?|. "opam remote remove %s" remotes
+  end;
+  List.iter add_remote extra_remotes
+end;
 
 List.iter pin pins;
 ?|. "opam pin add %s . -n" pkg;


### PR DESCRIPTION
If directory caching is enabled for `.opam`, the previous process for adding pins will fail due to duplicate names, e.g., extra0, extra1, etc. Removing all pins except the default before attempting to add them
avoids this problem.

For those that are not using directory caching or are not using `EXTRA_REMOTES`, the behavior should be unchanged.