### PR TITLE
Adding "precise" repo breaks OPAM depexts

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -61,6 +61,8 @@ install_on_linux () {
      "$(full_apt_version camlp4 $OCAML_VERSION)" \
      "$(full_apt_version camlp4-extra $OCAML_VERSION)" \
      opam
+  sudo add-apt-repository -r \
+     "deb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe"
 
   if [ "$UPDATE_GCC_BINUTILS" != "0" ] ; then
     echo "installing a recent gcc and binutils (mainly to get mirage-entropy-xen working!)"


### PR DESCRIPTION
Travis currently uses Ubuntu precise (12.04LTS).  When ```.travis-ocaml.sh``` adds "trusty" repo it breaks subsequent package installation with OPAM depexts.  Here is an example error message:

```
# The following new OS packages need to be installed: libhdf5-serial-dev
Not running as root, the following command will be run through "sudo":
    apt-get install -qq -yy libhdf5-serial-dev
E: Unable to correct problems, you have held broken packages.
opam-depext: internal error, uncaught exception:
             Failure("OS package installation failed")
```

This fix simply removes the extra package repos after they're needed.

See https://github.com/ocaml/opam-repository/pull/4831 for details.