### PR TITLE
travis-opam: update OS package sets before a depext

### DIFF
--- a/travis_opam.ml
+++ b/travis_opam.ml
@@ -61,7 +61,7 @@ let install args =
   begin match extra_deps with
     | None -> ()
     | Some deps ->
-      ?|. "opam depext %s" deps;
+      ?|. "opam depext -u %s" deps;
       ?|. "opam install %s" deps
   end;
 
@@ -76,7 +76,7 @@ let install args =
   end
 
 let install_with_depopts depopts =
-  ?|~ "opam depext %s" depopts;
+  ?|~ "opam depext -u %s" depopts;
   ?|~ "opam install %s" depopts;
   install ["-v"];
   ?|~ "opam remove %s -v" pkg;
@@ -121,7 +121,7 @@ List.iter pin pins;
 ?|  "opam install depext";
 
 (* Install the external dependencies *)
-?|~ "opam depext %s" pkg;
+?|~ "opam depext -u %s" pkg;
 
 (* Install the OCaml dependencies *)
 ?|~ "opam install %s --deps-only" pkg;


### PR DESCRIPTION
will address mirage/ocaml-uri#87 and other multi-distro failures